### PR TITLE
Update product API to save repmafia metadata

### DIFF
--- a/app/api/products/route.ts
+++ b/app/api/products/route.ts
@@ -14,13 +14,23 @@ function processApiData(data: any, platform: string) {
         platform,
         mainImages: data.Images || [],
         priceCNY: data.PriceCNY || 0,
+        formattedDimensions: data.FormattedDimensions || '',
         shopInfo: {
             shopName: data.ShopInfo?.ShopName,
             shopLogo: data.ShopInfo?.ShopLogo,
             shopId: data.ShopInfo?.ShopID,
         },
         dimensions: data.Dimensions || {},
-        skus: data.Skus || [], // Zapisujemy całą surową listę SKU
+        skus: Array.isArray(data.Skus)
+            ? data.Skus.map((sku: any) => {
+                const colorProp = sku.Properties?.find((p: any) => p.Name.toLowerCase().includes('color'));
+                const sizeProp = sku.Properties?.find((p: any) => p.Name.toLowerCase().includes('size'));
+                return {
+                    color: colorProp?.Value || null,
+                    size: sizeProp?.Value || null,
+                };
+            })
+            : [],
     };
 
     // Wyciąganie linków do obrazów z opisu (Description)
@@ -33,16 +43,14 @@ function processApiData(data: any, platform: string) {
     const colors = new Set<string>();
     const sizes = new Set<string>();
 
-    if (data.Skus) {
-        data.Skus.forEach((sku: any) => {
-            sku.Properties.forEach((prop: any) => {
-                if (prop.Name.toLowerCase().includes('color')) {
-                    colors.add(prop.Value);
-                }
-                if (prop.Name.toLowerCase().includes('size')) {
-                    sizes.add(prop.Value);
-                }
-            });
+    if (Array.isArray(processed.skus)) {
+        processed.skus.forEach((sku: any) => {
+            if (sku.color) {
+                colors.add(sku.color);
+            }
+            if (sku.size) {
+                sizes.add(sku.size);
+            }
         });
     }
 

--- a/models/Product.ts
+++ b/models/Product.ts
@@ -13,6 +13,8 @@ const ProductSchema = new Schema({
     descriptionImages: [String], 
     
     priceCNY: { type: Number },
+
+    formattedDimensions: String,
     
     // Unikalne, wyciągnięte z wariantów (SKUs)
     availableColors: [String],


### PR DESCRIPTION
## Summary
- store `formattedDimensions` in product model
- parse repmafia preview API response to extract formatted dimensions
- clean SKU data to keep only color and size
- deduplicate colors and sizes using the sanitized SKUs

## Testing
- `npm install` *(fails: dependency resolution error)*
- `npm run lint` *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68799ba22abc83328e7a74f68acb780e